### PR TITLE
fix type bug in to() method

### DIFF
--- a/cebra/integrations/sklearn/cebra.py
+++ b/cebra/integrations/sklearn/cebra.py
@@ -1282,21 +1282,21 @@ class CEBRA(BaseEstimator, TransformerMixin):
             raise TypeError(
                 "The 'device' parameter must be a string or torch.device object."
             )
-
-        if (not device == 'cpu') and (not device.startswith('cuda')) and (
-                not device == 'mps'):
-            raise ValueError(
-                "The 'device' parameter must be a valid device string or device object."
-            )
-
+        
         if isinstance(device, str):
-            device = torch.device(device)
+            if (not device == 'cpu') and (not device.startswith('cuda')) and (
+                    not device == 'mps'):
+                raise ValueError(
+                    "The 'device' parameter must be a valid device string or device object."
+                )
 
-        if (not device.type == 'cpu') and (
-                not device.type.startswith('cuda')) and (not device == 'mps'):
-            raise ValueError(
-                "The 'device' parameter must be a valid device string or device object."
-            )
+        elif isinstance(device, torch.device):
+            if (not device.type == 'cpu') and (
+                    not device.type.startswith('cuda')) and (not device == 'mps'):
+                raise ValueError(
+                    "The 'device' parameter must be a valid device string or device object."
+                )
+            device = device.type
 
         if hasattr(self, "device_"):
             self.device_ = device


### PR DESCRIPTION
The recently implemented to() method within the CEBRA class in sklearn integration has a bug in the type of the class attributes `device` and `device_`. The two bugs are:
- The logic of the if statements for type checking breaks when device is of type torch.device because of `device.startswith()`, which assumes device is of type str, yet the input type hint is `device: Union[str, torch.device]`
- When the method is used with input device of type str, the original method sets `self.device` (and `self.device_ `if existent) to a torch.device object. This causes downstream errors when calling other class methods such as `partial_fit()` after having called `to()`, because the method `_prepare_fit()` calls `sklearn_utils.check_device(self.device)` which fails when `self.device` is not of type str. 

The fix modifies the logic for type checking and sets class attribute `self.device` (and `self.device_ `if existent) to a str object always. 

